### PR TITLE
Configure furigana support and exemplary use it in chapter one.

### DIFF
--- a/config/.vitepress/config.mts
+++ b/config/.vitepress/config.mts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitepress'
+import furigana from 'furigana-markdown-it'
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -11,6 +12,9 @@ export default defineConfig({
     image: {
       // image lazy loading is disabled by default
       lazyLoading: true
+    },
+    config: (md) => {
+      md.use(furigana())
     }
   },
   head: [

--- a/config/.vitepress/theme/custom.css
+++ b/config/.vitepress/theme/custom.css
@@ -1,4 +1,12 @@
 :root {
     --vp-font-family-base: 'Chinese Quotes', 'Inter var', 'Inter', 'Noto Sans JP', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Helvetica, Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
     --vp-font-family-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', 'Noto Sans JP',monospace;
-  }
+
+    .vp-doc :not(pre) > code ruby > rt {
+        margin-bottom: 3px;
+        border-radius: 4px;
+        padding: 2px 4px;
+        background-color: var(--vp-code-bg);
+        transition: color .25s, background-color .5s;
+    }
+}

--- a/config/docs/1-the-basic-types-of-sentences.md
+++ b/config/docs/1-the-basic-types-of-sentences.md
@@ -26,25 +26,25 @@ Walk in Japanese is <code>あるく</code>. We need one more thing to make the c
 
 ## Copula sentences
 
-Now let's take an A is B sentence: <code>Sakura is Japanese</code>, or, as we say, <code>Sakura is a Japanese person</code>. So, A again is Sakura, B is にほんじん/日本人, which means Japanese person, and **once again we need が to link them together. So we're going to picture the A car, the main carriage, with a が on it, because the main carriage, the subject of the sentence, always carries a が, to link it to the engine.**
+Now let's take an A is B sentence: <code>Sakura is Japanese</code>, or, as we say, <code>Sakura is a Japanese person</code>. So, A again is Sakura, B is にほんじん / [日本人]{に ほん じん}, which means Japanese person, and **once again we need が to link them together. So we're going to picture the A car, the main carriage, with a が on it, because the main carriage, the subject of the sentence, always carries a が, to link it to the engine.**
 
-So, さくらが日本人 – and we need one more thing. There's one other thing that I want you to make friends with, and that's だ (da). <code>さくらが日本人だ</code> = <code>Sakura is a Japanese person</code>.
+So, さくらが[日本人]{に ほん じん} – and we need one more thing. There's one other thing that I want you to make friends with, and that's だ (da). <code>さくらが[日本人]{に ほん じん}だ</code> = <code>Sakura is a Japanese person</code>.
 
 ![](media/image632.webp)
 
 Now, you may have met this だ in its fancy form, です, but there are very good reasons for learning the plain, simple form first. So we're going to learn だ. Now if you look at だ, it's like an equals sign boxed off to the left. And this is a perfect mnemonic for what it does, because **だ tells us that A is B.**
 
-Why is it boxed off to the left? Because it only works one way. Think about this logically: さくらが日本人だ means <code>Sakura = Japanese person.</code> But it doesn't work the other way: Japanese people are Sakura – they're not all Sakura. Sakura is a Japanese person, but a Japanese person is not necessarily Sakura.
+Why is it boxed off to the left? Because it only works one way. Think about this logically: さくらが[日本人]{に ほん じん}だ means <code>Sakura = Japanese person.</code> But it doesn't work the other way: Japanese people are Sakura – they're not all Sakura. Sakura is a Japanese person, but a Japanese person is not necessarily Sakura.
 
 ## Adjective sentences
 
 So now we have an <code>A is B</code> sentence and an <code>A does B</code> sentence. There is one more form of the Japanese core sentence, for it has three forms. The third form is when we have a describing word, an adjective.
 
-**In Japanese, describing words end with い** (i), just as they often do in English: happy, sunny, cloudy, silly. In Japanese it's just the same: happy – うれしい/嬉しい; sad – かなしい/悲しい; blue – あおい/青い.
+**In Japanese, describing words end with い** (i), just as they often do in English: happy, sunny, cloudy, silly. In Japanese it's just the same: happy – うれしい / [嬉]{うれ}しい; sad – かなしい / [悲]{かな}しい; blue – あおい / [青]{あお}い.
 
-Now, we don't have to learn all these, but we do need to know about Japanese adjectives ending in い because they make the third kind of sentence. So let's take an easy one: ペン (that's a nice easy word because it means pen) – <code>ペンが赤い/あかい</code> = <code>pen is red</code>.
+Now, we don't have to learn all these, but we do need to know about Japanese adjectives ending in い because they make the third kind of sentence. So let's take an easy one: ペン (that's a nice easy word because it means pen) – <code>ペンが[赤]{あか}い</code> = <code>pen is red</code>.
 
-Now, you notice that we don't have a だ on this sentence. Why is that? **Because the い-adjective あかい/赤い (red) – it doesn't mean red, it means is-red. The だ function, the equals function, is built into those い-adjectives.**
+Now, you notice that we don't have a だ on this sentence. Why is that? **Because the い-adjective [赤]{あか}い (あかい, red) – it doesn't mean red, it means is-red. The だ function, the equals function, is built into those い-adjectives.**
 
 ![](media/image557.webp)
 

--- a/config/docs/1-the-basic-types-of-sentences.md
+++ b/config/docs/1-the-basic-types-of-sentences.md
@@ -20,31 +20,31 @@ In Japanese, if we want to say <code>Sakura walks</code> (A does B: Sakura walks
 
 ![](media/image1055.webp)
 
-Walk in Japanese is <code>あるく</code>. We need one more thing to make the core Japanese sentence, and **that is the linchpin of every sentence, が** (ga). 
+Walk in Japanese is <code>あるく</code>. We need one more thing to make the core Japanese sentence, and **that is the linchpin of every sentence, が** (ga).
 
 **が is the center of Japanese grammar. Every Japanese sentence revolves around が. In some sentences we're not going to be able to see the が, but it's always there, and it's always doing the same job. It links together A and B and turns them into a sentence.** So, our core <code>A does B</code> sentence is <code>**さくらが**あるく</code> = <code>**Sakura** walks</code>.
 
 ## Copula sentences
 
-Now let's take an A is B sentence: <code>Sakura is Japanese</code>, or, as we say, <code>Sakura is a Japanese person</code>. So, A again is Sakura, B is にほんじん / [日本人]{に ほん じん}, which means Japanese person, and **once again we need が to link them together. So we're going to picture the A car, the main carriage, with a が on it, because the main carriage, the subject of the sentence, always carries a が, to link it to the engine.**
+Now let's take an A is B sentence: <code>Sakura is Japanese</code>, or, as we say, <code>Sakura is a Japanese person</code>. So, A again is Sakura, B is [日本人]{にほんじん}, which means Japanese person, and **once again we need が to link them together. So we're going to picture the A car, the main carriage, with a が on it, because the main carriage, the subject of the sentence, always carries a が, to link it to the engine.**
 
-So, さくらが[日本人]{に ほん じん} – and we need one more thing. There's one other thing that I want you to make friends with, and that's だ (da). <code>さくらが[日本人]{に ほん じん}だ</code> = <code>Sakura is a Japanese person</code>.
+So, さくらが[日本人]{にほんじん} – and we need one more thing. There's one other thing that I want you to make friends with, and that's だ (da). <code>さくらが[日本人]{にほんじん}だ</code> = <code>Sakura is a Japanese person</code>.
 
 ![](media/image632.webp)
 
 Now, you may have met this だ in its fancy form, です, but there are very good reasons for learning the plain, simple form first. So we're going to learn だ. Now if you look at だ, it's like an equals sign boxed off to the left. And this is a perfect mnemonic for what it does, because **だ tells us that A is B.**
 
-Why is it boxed off to the left? Because it only works one way. Think about this logically: さくらが[日本人]{に ほん じん}だ means <code>Sakura = Japanese person.</code> But it doesn't work the other way: Japanese people are Sakura – they're not all Sakura. Sakura is a Japanese person, but a Japanese person is not necessarily Sakura.
+Why is it boxed off to the left? Because it only works one way. Think about this logically: さくらが[日本人]{にほんじん}だ means <code>Sakura = Japanese person.</code> But it doesn't work the other way: Japanese people are Sakura – they're not all Sakura. Sakura is a Japanese person, but a Japanese person is not necessarily Sakura.
 
 ## Adjective sentences
 
 So now we have an <code>A is B</code> sentence and an <code>A does B</code> sentence. There is one more form of the Japanese core sentence, for it has three forms. The third form is when we have a describing word, an adjective.
 
-**In Japanese, describing words end with い** (i), just as they often do in English: happy, sunny, cloudy, silly. In Japanese it's just the same: happy – うれしい / [嬉]{うれ}しい; sad – かなしい / [悲]{かな}しい; blue – あおい / [青]{あお}い.
+**In Japanese, describing words end with い** (i), just as they often do in English: happy, sunny, cloudy, silly. In Japanese it's just the same: happy – [嬉]{うれ}しい; sad – [悲]{かな}しい; blue – [青]{あお}い.
 
 Now, we don't have to learn all these, but we do need to know about Japanese adjectives ending in い because they make the third kind of sentence. So let's take an easy one: ペン (that's a nice easy word because it means pen) – <code>ペンが[赤]{あか}い</code> = <code>pen is red</code>.
 
-Now, you notice that we don't have a だ on this sentence. Why is that? **Because the い-adjective [赤]{あか}い (あかい, red) – it doesn't mean red, it means is-red. The だ function, the equals function, is built into those い-adjectives.**
+Now, you notice that we don't have a だ on this sentence. Why is that? **Because the い-adjective [赤]{あか}い (red) – it doesn't mean red, it means is-red. The だ function, the equals function, is built into those い-adjectives.**
 
 ![](media/image557.webp)
 

--- a/config/docs/2-the-invisible-carriage-and-the-を-particle.md
+++ b/config/docs/2-the-invisible-carriage-and-the-を-particle.md
@@ -54,7 +54,7 @@ We can say that <code>I</code> is the default value of the zero pronoun, the inv
 
 ![](media/image617.webp)
 
-If I say, <code>土曜日だ</code> (土曜日/どようび means Saturday), I'm saying <code>(It) is Saturday</code>. What's <code>it</code>? Today is. All these sentences are full, complete Japanese sentences, with a が-marked subject/ A carriage/main carriage, and an engine.
+If I say, <code>[土曜日]{どようび}だ</code> ([土曜日]{どようび} means Saturday), I'm saying <code>(It) is Saturday</code>. What's <code>it</code>? Today is. All these sentences are full, complete Japanese sentences, with a が-marked subject/A carriage/main carriage, and an engine.
 
 ![](media/image490.webp)
 
@@ -66,18 +66,18 @@ So the を car looks like this, and as you see, it's white. It's white because i
 
 ![](media/image77.webp)
 
-So let's take a sentence here: <code>わたしがケーキを食べる</code>. This means <code>I eat cake</code>.
+So let's take a sentence here: <code>わたしがケーキを[食]{た}べる</code>. This means <code>I eat cake</code>.
 
 ![](media/image146.webp)
 
 Now, the core sentence here is <code>I eat</code>. Those are the two black carriages. The white carriage, <code>ケーキを</code>, is telling us more about the engine. The core sentence is <code>I eat</code> and <code>ケーキを</code> is telling us what it is that I eat.
 
-Now, the interesting thing here is that we may often see this said like this: <code>ケーキをたべる</code>. And you already know what's going on when this happens. This is another case where we have the invisible A car.
+Now, the interesting thing here is that we may often see this said like this: <code>ケーキを[食]{た}べる</code>. And you already know what's going on when this happens. This is another case where we have the invisible A car.
 
 ![](media/image280.webp)
 
-**We can't have a sentence without a が. We can't have an action being done without a doer.** If we say <code>ケーキをたべる</code>, what we're really saying is <code>(zeroが)ケーキをたべる</code>. And the default value for <code>zero</code>, for the invisible carriage, is <code>わたし</code>. So usually this is going to be <code>I eat cake</code>, although if you were talking about someone else at the time, it might mean that that person eats cake.
+**We can't have a sentence without a が. We can't have an action being done without a doer.** If we say <code>ケーキを[食]{た}べる</code>, what we're really saying is <code>(zeroが)ケーキを[食]{た}べる</code>. And the default value for <code>zero</code>, for the invisible carriage, is <code>[私]{わたし}</code>. So usually this is going to be <code>I eat cake</code>, although if you were talking about someone else at the time, it might mean that that person eats cake.
 
 ::: info
-Just in case - as can be seen from from the pictures, every particle attaches to/assigns itself to the word BEFORE it, Not after it.
+Just in case - as can be seen from the pictures, every particle attaches to/assigns itself to the word BEFORE it, Not after it.
 :::

--- a/config/docs/22-ては-ても.md
+++ b/config/docs/22-ては-ても.md
@@ -18,7 +18,7 @@ Japanese is quite a noun-centered language, because all the words that come in f
 ![](media/image678.webp)
 
 **But fundamentally they're nouns.** So it's always a good guess when you don't know what a word is, that it's quite likely to be a noun. <code>空っぽ</code> is a noun, <code>empty</code>.
-<code>でも, びんは**空っぽ**だった</code> – <code>However, the jar was **empty**</code>.
+<code>でも, びんは<b>[空]{から}っぽ</b>だった</code> – <code>However, the jar was **empty**</code>.
 <code>アリスは空っぽのびんでも下へ落としては悪いと思った.</code>
 Here again, we're going to see some other uses of the て-form.
 

--- a/config/docs/3-the-は-particle.md
+++ b/config/docs/3-the-は-particle.md
@@ -4,7 +4,7 @@
 
 こんにちは。
 
-Welcome to Lesson 3. Some of you who have done some Japanese already may be wondering how I've managed to get through two entire lessons without using or even mentioning the は *(always read as wa)* particle. I'm well aware that most courses start you on は from the beginning. <code>わたしはアメリカ人だ</code> <code>ペンはあおい.</code> And this is really a very very bad idea because it leaves you completely unclear about what the particles really do and about the logical structure of sentences.
+Welcome to Lesson 3. Some of you who have done some Japanese already may be wondering how I've managed to get through two entire lessons without using or even mentioning the は *(always read as wa)* particle. I'm well aware that most courses start you on は from the beginning. <code>わたしはアメリカ[人]{じん}だ.</code> <code>ペンはあおい.</code> And this is really a very, very bad idea because it leaves you completely unclear about what the particles really do and about the logical structure of sentences.
 
 However, we're now ready to look at the は particle and find out what it does and, just as important, what it doesn't do. **The は particle can never be a part of the core sentence. It can never be one of the black carriages**, **the main car A** (the thing we are saying something about) **or the engine B** (the thing we are saying about it).
 
@@ -22,25 +22,25 @@ So if は is not a black car or a white car, what kind of a carriage is it? Well
 
 That's right, it's a flag. Why do we depict it as a flag? Because that is what は does. **It flags something as the topic of the sentence. It doesn't say anything about it. That's what the logical sentence is there for. Wa simply flags the topic.**
 
-Now, some of the textbooks will tell you that a sentence like <code>わたしはアメリカ人だ</code> literally means <code>As for me, I am an American</code>, and that is exactly correct. If they would stick with that logic and carry it through, we wouldn't have the trouble we have.
+Now, some of the textbooks will tell you that a sentence like <code>わたしはアメリカ[人]{じん}だ</code> literally means <code>As for me, I am an American</code>, and that is exactly correct. If they would stick with that logic and carry it through, we wouldn't have the trouble we have.
 
-So, <code>わたし/私は</code> means <code>as for me</code>. <code>アメリカ人だ</code> means <code>=American</code> or <code>am American</code>. So as you see, with a sentence like this something is missing, both from the Japanese and the English. We can't say <code>as for me, am American</code>. Neither can we have a sentence without an A car, without a が-marked doer. So if we put the A car in, it makes sense in both English and Japanese.
+So, <code>[私]{わたし}は</code> means <code>as for me</code>. <code>アメリカ[人]{じん}だ</code> means <code>= American</code> or <code>am American</code>. So as you see, with a sentence like this something is missing, both from the Japanese and the English. We can't say <code>as for me, am American</code>. Neither can we have a sentence without an A car, without a が-marked doer. So if we put the A car in, it makes sense in both English and Japanese.
 
 ![](media/image487.webp)
 
-<code>私は(**zeroが)**アメリカ人だ</code> – <code>As for me, (**I)** am an American.</code>
+<code>[私]{わたし}は<b>(zeroが)</b>アメリカ[人]{じん}だ</code> – <code>As for me, (**I**) am an American.</code>
 
-Now, some of you may be saying, "Isn't it over-complicated? Can't we just pretend that **わたしは** is the main car of the sentence?" And the answer to that is <code>**No**</code>. Because although it works in this case and some other cases, it doesn't work in every case and that is why we really mustn't do it.
+Now, some of you may be saying, "Isn't it over-complicated? Can't we just pretend that **[私]{わたし}は** is the main car of the sentence?" And the answer to that is <code>**No**</code>. Because although it works in this case and some other cases, it doesn't work in every case and that is why we really must not do it.
 
-Let's take an example. There's an old joke among Japanese learners and it's only possible because of how badly Japanese is taught. The joke is: A group of people are dining in a restaurant and they're discussing what they're going to eat, and somebody says, <code>わたしはうなぎだ</code>. Unagi/うなぎ means eel, so the joke is that this person has literally said, <code>I am an eel</code>.
+Let's take an example. There's an old joke among Japanese learners, and it's only possible because of how badly Japanese is taught. The joke is: A group of people are dining in a restaurant, and they're discussing what they're going to eat, and somebody says, <code>[私]{わたし}はうなぎだ</code>. Unagi/うなぎ means eel, so the joke is that this person has literally said, <code>I am an eel</code>.
 
-After all, if <code>わたしはアメリカ人だ</code> means <code>I am an American</code>, then <code>わたしはうなぎだ</code> must mean <code>I am an eel</code>. That's absolutely perfect logic – **except that <code>わたしはアメリカ人だ</code> doesn't mean <code>I am an American</code>. It means <code>As for me, I am an American</code>.**
+After all, if <code>[私]{わたし}はアメリカ[人]{じん}だ</code> means <code>I am an American</code>, then <code>[私]{わたし}はうなぎだ</code> must mean <code>I am an eel</code>. That's absolutely perfect logic – **except that <code>[私]{わたし}はアメリカ[人]{じん}だ</code> doesn't mean <code>I am an American</code>. It means <code>As for me, I am an American</code>.**
 
-As we know, the default value of the invisible car, the zero pronoun, is <code>私/わたし</code>, but that isn't its only value. Its value depends on context.
+As we know, the default value of the invisible car, the zero pronoun, is <code>[私]{わたし}</code>, but that isn't its only value. Its value depends on context.
 
 ---
 
-In <code>わたしはアメリカ人だ</code> (<code>As for me, I am an American</code>) the value of the zero pronoun is indeed <code>私/わたし</code>. But in <code>わたしはうなぎだ</code>, which is <code>わたしは(**zeroが)**うなぎだ</code>, zero is not <code>私</code>. Zero is <code>it</code>. <code>It</code> is the thing we are talking about, the subject of the conversation: what we are eating for dinner.
+In <code>[私]{わたし}はアメリカ[人]{じん}だ</code> (<code>As for me, I am an American</code>) the value of the zero pronoun is indeed <code>[私]{わたし}</code>. But in <code>[私]{わたし}はうなぎだ</code>, which is <code>[私]{わたし}は(**zeroが**)うなぎだ</code>, zero is not <code>[私]{わたし}</code>. Zero is <code>it</code>. <code>It</code> is the thing we are talking about, the subject of the conversation: what we are eating for dinner.
 
 ![](media/image377.webp)
 
@@ -50,13 +50,13 @@ The car we're going to introduce today is a white car, and this is the に (ni) 
 
 ![](media/image338.webp)
 
-But let's take this を sentence: <code>わたしがボールをなげる</code>
+But let's take this を sentence: <code>[私]{わたし}がボールをなげる</code>
 
-ボール is ball and なげる means throw. So this is, <code>I throw a ball</code>. The core sentence is <code>I throw</code> – <code>わたしがなげる</code>, and the white car tells us what I threw: it was a ball.
+ボール is ball and なげる means throw. So this is, <code>I throw a ball</code>. The core sentence is <code>I throw</code> – <code>[私]{わたし}がなげる</code>, and the white car tells us what I threw: it was a ball.
 
 ![](media/image299.webp)
 
-Now, if we say, <code>わたしがボールをさくらになげる</code>, this means <code>I throw a ball at Sakura</code> (or <code>to Sakura</code>). **Sakura is the destination, the target, of my throwing.**
+Now, if we say, <code>[私]{わたし}がボールをさくらになげる</code>, this means <code>I throw a ball at Sakura</code> (or <code>to Sakura</code>). **Sakura is the destination, the target, of my throwing.**
 
 ![](media/image901.webp)
 
@@ -66,15 +66,15 @@ So if I say, <code>わたしにさくらがボールをなげる</code>, I'm say
 
 ![](media/image165.webp)
 
-If I say, <code>ボールがわたしにさくらをなげる</code>, I'm saying, <code>The ball throws Sakura at me</code>. It doesn't make any sense, but we might want to say it in a fantasy novel or something.
+If I say, <code>ボールが[私]{わたし}にさくらをなげる</code>, I'm saying, <code>The ball throws Sakura at me</code>. It doesn't make any sense, but we might want to say it in a fantasy novel or something.
 
 ![](media/image864.webp)
 
-**We can say whatever we like in Japanese so long as we have the logic of the particles correct.** But now let's introduce は into this sentence: <code>わたし**は**さくらにボールをなげる.</code> This is <code>わたし**は**(zeroが)さくらにボールをなげる</code>. As we know, what it means is <code>As for me, I throw the ball at Sakura</code>.
+**We can say whatever we like in Japanese so long as we have the logic of the particles correct.** But now let's introduce は into this sentence: <code>[私]{わたし}**は**さくらにボールをなげる.</code> This is <code>[私]{わたし}**は**(zeroが)さくらにボールをなげる</code>. As we know what it means is <code>As for me, I throw the ball at Sakura</code>.
 
 ![](media/image106.webp)
 
-Now let's give the は to the ball: <code>ボールは私がさくらに**(zeroを)**なげる</code>. What we are saying now is <code>As for the ball, I throw it at Sakura</code>.
+Now let's give the は to the ball: <code>ボールは[私]{わたし}がさくらに<b>(zeroを)</b>なげる</code>. What we are saying now is <code>As for the ball, I throw it at Sakura</code>.
 
 ![](media/image877.webp)
 

--- a/config/docs/4-japanese-verb-tenses.md
+++ b/config/docs/4-japanese-verb-tenses.md
@@ -4,7 +4,7 @@
 
 こんにちは。
 
-Today we're going to talk about tenses. Up to now, we've only been using one tense, and that is the one represented by the plain dictionary form of verbs: 食べる/たべる - eat; 歩く/あるく - walk, and so forth. To use natural-sounding Japanese, we need three tenses. You might think they would be past, present and future, but in fact they're not.
+Today we're going to talk about tenses. Up to now, we've only been using one tense, and that is the one represented by the plain dictionary form of verbs: [食]{た}べる - eat; [歩]{ある}く - walk, and so forth. To use natural-sounding Japanese, we need three tenses. You might think they would be past, present and future, but in fact they're not.
 
 ## The non-past tense
 
@@ -14,13 +14,13 @@ The one we've been using up to now is not a present tense. It's called the non-p
 
 Well, actually it isn't confusing at all, and what makes it confusing is, for a change, not the fact that Japanese is taught in a strange way, but the fact that English is taught in a strange way. The truth is that the Japanese non-past tense is very similar to the English non-past tense.
 
-What is the English non-past tense? Well, it is the plain dictionary form of English words: eat, walk, etc. Why do I call it a non-past tense? Well, let's take an example. Suppose you get a message on your 携帯/けいたい (phone) saying, <code>I walked to the cafe and now I eat cake and drink coffee</code>. What would you know about the person who sent that message? Well, you'd know that it was not a native English speaker, wouldn't you? Because no native English speaker says <code>I eat cake and I drink coffee</code> when they mean <code>I am eating cake and drinking coffee right now</code>.
+What is the English non-past tense? Well, it is the plain dictionary form of English words: eat, walk, etc. Why do I call it a non-past tense? Well, let's take an example. Suppose you get a message on your [携帯]{けいたい} (phone) saying, <code>I walked to the cafe and now I eat cake and drink coffee</code>. What would you know about the person who sent that message? Well, you'd know that it was not a native English speaker, wouldn't you? Because no native English speaker says <code>I eat cake and I drink coffee</code> when they mean <code>I am eating cake and drinking coffee right now</code>.
 
 When so we say <code>I eat cake</code>? Well, we might say it when we mean that we eat cake sometimes: "I eat cake. I'm not one of these people who doesn't eat cake. I do eat cake. Whenever there's any cake around, I eat it. But that doesn't mean I'm eating cake right at this moment."
 
 When else do we use the English non-past plain form of verbs? Well, sometimes we use them for future events: <code>Next week I fly to Tokyo.</code> <code>Next month I have an exam.</code> And sometimes we use them for something that's going on right now, but not mostly. For example, in a literary description: "The sun sinks over the sea and a small happy robot runs across the beach." But that isn't the way we use it most of the time in everyday speech, is it?
 
-So, the Japanese non-past tense is very similar in the way it functions to the English non-past tense. If you understand one you can pretty much understand the other. **Most of the time, the Japanese non-past tense refers to future events.** <code>いぬがたべる</code> - <code>The dog will-eat</code>; <code>さくらがあるく</code> - <code>Sakura will-walk.</code>
+So, the Japanese non-past tense is very similar in the way it functions to the English non-past tense. If you understand one you can pretty much understand the other. **Most of the time, the Japanese non-past tense refers to future events.** <code>[犬]{いぬ}がたべる</code> - <code>The dog will-eat</code>; <code>さくらがあるく</code> - <code>Sakura will-walk.</code>
 
 ![](media/image861.webp)
 
@@ -32,21 +32,21 @@ If we want to say something more natural, like <code>Sakura is walking</code>, w
 
 Fortunately, in Japanese we don't have all these different forms of the word <code>to be</code>. We use the same word every time, and the word is <code>いる</code>. <code>いる</code> means <code>be</code> **in relation to animals and people**, and to make this continuous present tense, we always use <code>いる</code>.
 
-So, <code>Sakura is walking</code> – <code>さくらがあるいている</code>. <code>Dog is eating</code> – <code>いぬがたべている</code>
+So, <code>Sakura is walking</code> – <code>さくらがあるいている</code>. <code>Dog is eating</code> – <code>[犬]{いぬ}がたべている</code>
 
 ![](media/image612.webp)
 
-Now, let's notice that in a sentence like <code>いぬがたべている,</code> we have something we haven't yet seen, and that's a white engine. **A white engine is an element that could be an engine but in this case it's NOT the engine of this sentence. It's modifying, or telling us more about, one of the core elements of the sentence.**
+Now, let's notice that in a sentence like <code>[犬]{いぬ}がたべている,</code> we have something we haven't yet seen, and that's a white engine. **A white engine is an element that could be an engine but in this case it's NOT the engine of this sentence. It's modifying, or telling us more about, one of the core elements of the sentence.**
 
 ![](media/image1035.webp)
 
-So, the core of this sentence is <code>いぬがいる</code> - <code>the dog is</code>. But the dog isn't just existing – the dog is doing something. And that white engine tells us what it is doing. It is <code>eating</code>. And we're going to see this white engine structure over and over again as we go deeper into Japanese.
+So, the core of this sentence is <code>[犬]{いぬ}がいる</code> - <code>the dog is</code>. But the dog isn't just existing – the dog is doing something. And that white engine tells us what it is doing. It is <code>eating</code>. And we're going to see this white engine structure over and over again as we go deeper into Japanese.
 
-And just as in English we don't say <code>the dog is eat</code>, we use a special form of the verb that goes along with the verb of being. So in English we say <code>is walking</code>, <code>is eating</code>. In Japanese we say <code>食べている/たべている</code>, <code>歩いている/あるいている</code>.
+And just as in English we don't say <code>the dog is eat</code>, we use a special form of the verb that goes along with the verb of being. So in English we say <code>is walking</code>, <code>is eating</code>. In Japanese we say <code>[食]{た}べている</code>, <code>[歩]{ある}いている</code>.
 
 ---
 
-Now, how do we form this <code>て-form</code>, which is the form we use for making the continuous present? With a word like <code>食べる/たべる</code>, it's very easy indeed. All we have to do is take off the <code>る</code> and put <code>て</code> in its place. たべる becomes たべて.
+Now, how do we form this <code>て-form</code>, which is the form we use for making the continuous present? With a word like <code>[食]{た}べる</code>, it's very easy indeed. All we have to do is take off the <code>る</code> and put <code>て</code> in its place. [食]{た}べる becomes [食]{た}べて.
 
 The bad news is that with other verbs, we do have slightly different ways of attaching the <code>て</code>. Apart from the plain る-form, there are four other ways. The textbooks will say five, but in fact two of them are so similar that we can treat them as four. And I've made a video on exactly what these ways are *(Lesson 5, so the next lesson).* And it makes it much simpler than most explanations.
 
@@ -54,15 +54,15 @@ So it's very important to watch that so that you can learn how to form the conti
 
 ## Past tense
 
-So, how do we put things into the past tense? Fortunately that's very easy indeed. **All we do is add <code>た</code> – that's the whole thing.** So, <code>いぬがたべる</code> – <code>dog will-eat</code> / <code>いぬがたべた</code> – <code>dog ate</code>.
+So, how do we put things into the past tense? Fortunately that's very easy indeed. **All we do is add <code>た</code> – that's the whole thing.** So, <code>[犬]{いぬ}がたべる</code> – <code>dog will-eat</code> / <code>[犬]{いぬ}がたべた</code> – <code>dog ate</code>.
 
 Now, there are different ways of attaching <code>た</code> to different kinds of verb, verbs with different endings, but the good news here is that they are exactly the same as the ways that you attach <code>て</code>. So once you've learned the ways that <code>て</code> attaches, you've also learned the ways that <code>た</code> attaches. So if you watch that て-form video ***(Lesson 5)***, you'll be able to do both the continuous present and the past.
 
-Now, there's one more thing about time expressions that is useful to learn now. If we want to make it clear, when we say <code>私はケーキを食べる</code>, we're talking about a future event, we can say <code>明日/あした</code> (which means <code>tomorrow</code>) <code>あしたケーキを食べる</code>. That's all we have to do.
+Now, there's one more thing about time expressions that is useful to learn now. If we want to make it clear, when we say <code>[私]{わたし}はケーキを[食]{た}べる</code>, we're talking about a future event, we can say <code>[明日]{あした}</code> (which means <code>tomorrow</code>) <code>[明日]{あした}ケーキを[食]{た}べる</code>. That's all we have to do.
 
 ## Time expressions
 
-We just say <code>tomorrow</code> before we say the rest of the sentence, just as we do in English. <code>Tomorrow I'm going to eat cake</code> – <code>あした *(zeroが)* ケーキを食べる</code>.  
+We just say <code>tomorrow</code> before we say the rest of the sentence, just as we do in English. <code>Tomorrow I'm going to eat cake</code> – <code>あした *(zeroが)* ケーキを[食]{た}べる</code>.
 ::: info
 Sometimes I add zeroが even when Dolly does not say it in the transcript, BUT she shows it in the videos, I obviously only add it then if it is shown by her, I do not do it on my own…
 :::
@@ -77,7 +77,7 @@ And with all relative time expressions like that: yesterday, last week, next yea
 
 However, when we have an <code>absolute time expression</code>, an expression that is not relative to the present, such as Tuesday or six o'clock, then **we have to use <code>に</code>**.
 
-Tuesday is <code>火曜日/かようび</code> and we may may say <code>かようびに *(zeroが)* ケーキをたべる</code> – <code>On Tuesday (I) will eat cake.</code>
+Tuesday is <code>[火曜日]{かようび}</code> and we may say <code>[火曜日]{かようび}に *(zeroが)* ケーキを[食]{た}べる</code> – <code>On Tuesday (I) will eat cake.</code>
 
 ![](media/image441.webp)
 

--- a/config/docs/5-verb-groups-and-the-て-form.md
+++ b/config/docs/5-verb-groups-and-the-て-form.md
@@ -110,7 +110,7 @@ And now we just have one left, and that is す. **And verbs ending in -す drop 
 So はなす - talk, becomes はなして; the ます helper verb, which turns verbs into formal *(polite)* verbs, in the past tense becomes ました.
 
 ::: info
-Whenever Dolly uses the term <code>formal</code> for です or ます, it should be POLITE instead, there is a difference between the two terms in Japanese, not sure why she did not bring this one up, but it is quite important to distinguish, if you look into their definitions, dictionaries mark them as polite. **They are part of the 丁寧語 (polite language). So it is more accurate to call them polite instead.**
+Whenever Dolly uses the term <code>formal</code> for です or ます, it should be POLITE instead, there is a difference between the two terms in Japanese, not sure why she did not bring this one up, but it is quite important to distinguish, if you look into their definitions, dictionaries mark them as polite. **They are part of the [丁寧語]{てい ねい ご} (polite language). So it is more accurate to call them polite instead.**
 :::
 
 So now we have all the godan verbs. Didn't I look young in that old video?

--- a/config/docs/5-verb-groups-and-the-て-form.md
+++ b/config/docs/5-verb-groups-and-the-て-form.md
@@ -32,7 +32,7 @@ The third group of verbs is irregular verbs, and the good news here is that ther
 
 ![](media/image565.webp)
 
-You know those pages and pages of irregular verbs in your Spanish or French textbook? Well, Japanese has just two. There are a couple of other verbs that are irregular in just one small respect, but very few. **The irregular verbs are くる (come) and する (do).**
+You know those pages and pages of irregular verbs in your Spanish or French textbook? Well, Japanese has just two. There are a couple of other verbs that are irregular in just one small respect, but very few. **The irregular verbs are [来る]{くる} (come) and する (do).**
 
 ## The -て Form
 
@@ -40,7 +40,7 @@ So now that we know the three groups, we're going to take a look at how you make
 
 And as I demonstrated last week, ichidan verbs are always very easy. **You never do anything except take off the -る and put on whatever you're going to put on, in this case a て or a た.**
 
-As for the godan verbs, they fall into five groups, as you would expect (五段/ごだん, five-level verbs), and I made a video about this a while ago. So what I'm going to do is run that video right now, because it explains things pretty clearly.
+As for the godan verbs, they fall into five groups, as you would expect ([五段]{ごだん}, five-level verbs), and I made a video about this a while ago. So what I'm going to do is run that video right now, because it explains things pretty clearly.
 
 All right, roll the video.
 
@@ -52,19 +52,19 @@ And although that seems a little bit difficult, it really isn't. We can combine 
 
 ### The First Godan Group
 
-The first group is what I call the UTSURU/うつる verbs. Those are the verbs ending in -う, -つ and -る. The word うつる in Japanese – if you don't know it, now is a good time to learn it – うつる means to move from one thing to another, and that's exactly what we're doing here – moving our verbs from one type to another.
+The first group is what I call the UTSURU/うつる verbs. Those are the verbs ending in -う, -つ and -る. The word うつる in Japanese – if you don't know it, now is a good time to learn it – [移]{うつ}る means to move from one thing to another, and that's exactly what we're doing here – moving our verbs from one type to another.
 
 So the verbs which end in -う, -つ and -る all transform in the same way to the て-form. **We take off the -う, the -つ or the -る, and we replace it with a small -っplus て (or た in the た-form).**
 
-So わらう - laugh, becomes わらって (Waratte);  
-もつ - hold, becomes もって (Motte);  
-and とる - take, becomes とって (Totte).
+So [笑う]{わらう} - laugh (warau), becomes [笑って]{わらって} (waratte);
+[持つ]{もつ} - hold (motsu), becomes [持って]{もって} (motte);
+and [取る]{とる} - take (toru), becomes [取って]{とって} (totte).
 
 Now, you'll notice that うつる has つ in the middle.
 
 ![](media/image994.webp)
 
-And the て-form of the うつる verbs is formed by using a small っ plus that て. **It's the only group that has つ in it, and it's the only group that has a つ in the て-form ending.**  
+And the て-form of the うつる verbs is formed by using a small っ plus that て. **It's the only group that has つ in it, and it's the only group that has a つ in the て-form ending.**
 
 So it's really easy to remember.
 
@@ -80,26 +80,26 @@ So, this group I call the New Boom group because there isn't a Japanese word tha
 
 ![](media/image35.webp)
 
-It's not a sharp sound like す, つ, く, and it's not a neutral sound like る or う. It's a dull sound – ぬ, ぶ, む (Nu, Bu, Mu). And this is important because the ending is also a dull sound. **The て-form ending is -んで, the た-form is -んだ.**
+It's not a sharp sound like す, つ, く, and it's not a neutral sound like る or う. It's a dull sound – ぬ, ぶ, む (nu, bu, mu). And this is important because the ending is also a dull sound. **The て-form ending is -んで, the た-form is -んだ.**
 
-So しぬ, **the only -ぬ ending verb**, becomes しんで / しんだ;  
-のむ - drink, becomes のんで / のんだ; あそぶ - play, becomes あそんで / あそんだ.
+So [死]{し}ぬ, **the only -ぬ ending verb**, becomes [死]{し}んで / [死]{し}んだ;
+[飲]{の}む - drink, becomes [飲]{の}んで / [飲]{の}んだ; [遊]{あそ}ぶ - play, becomes [遊]{あそ}んで / [遊]{あそ}んだ.
 
-So that's the New Boom group, the dull-ending verbs. And because only a limited number of the possible kana can be used as a verb ending, they include all the dull sounds **except for ぐ (Gu).** We'll come to that right now.
+So that's the New Boom group, the dull-ending verbs. And because only a limited number of the possible kana can be used as a verb ending, they include all the dull sounds **except for ぐ (gu).** We'll come to that right now.
 
 ### The Third & Fourth Godan Group
 
 I told you that two of the groups could be combined - and that is the く and ぐ group. **To make the て form of a -く ending verb, we cut off the -く and add -いて, or -いた in the た form.**
 
-So あるく - walk, becomes あるいて / あるいた.
+So [歩く]{あるく} - walk, becomes [歩いて]{あるいて} / [歩いた]{あるいた}.
 
 Now, if we have a〃(ten-ten) on that -く, to make it into a -ぐ, it's exactly the same, except that there is also a ten-ten on the て-ending.
 
 ![](media/image459.webp)
 
-So あるく becomes あるいて, but およぐ - to swim, becomes およいで.
+So [歩く]{あるく} becomes [歩いて]{あるいて}, but [泳ぐ]{およぐ} - to swim, becomes [泳いで]{およいで}.
 
-But, as you see, the two are more or less identical. It's just that if there's a ten-ten on the original verb, there's a ten-ten on the て-form too. あるく, あるいて; およぐ, およいで.
+But, as you see, the two are more or less identical. It's just that if there's a ten-ten on the original verb, there's a ten-ten on the て-form too. [歩く]{あるく}, [歩いて]{あるいて}; [泳ぐ]{およぐ}, [泳いで]{およいで}.
 
 ### The Fifth Godan Group
 
@@ -107,7 +107,7 @@ And now we just have one left, and that is す. **And verbs ending in -す drop 
 
 ![](media/image491.webp)
 
-So はなす - talk, becomes はなして; the ます helper verb, which turns verbs into formal *(polite)* verbs, in the past tense becomes ました.
+So [話す]{はなす} - talk, becomes [話して]{はなして}; the ます helper verb, which turns verbs into formal *(polite)* verbs, in the past tense becomes ました.
 
 ::: info
 Whenever Dolly uses the term <code>formal</code> for です or ます, it should be POLITE instead, there is a difference between the two terms in Japanese, not sure why she did not bring this one up, but it is quite important to distinguish, if you look into their definitions, dictionaries mark them as polite. **They are part of the [丁寧語]{てい ねい ご} (polite language). So it is more accurate to call them polite instead.**
@@ -117,13 +117,13 @@ So now we have all the godan verbs. Didn't I look young in that old video?
 
 ![](media/image94.webp)
 
-### The Exceptions 
+### The Exceptions
 
 Now, we are just going to look at the exceptions. **There are only three altogether: our two irregular verbs and one other small one.**
 
-And these are very simple. くる (come) becomes きて; する (do) becomes して.
+And these are very simple. [来る]{くる} (<code>くる</code> - come) becomes [来て]{きて} (**<code>きて</code>**); <code>する</code> (do) becomes <code>して</code>.
 
-And いく – the verb いく (to go) – because it ends in -く, you would expect it to become いいて, but it doesn't, it becomes **いって**.
+And <code>いく</code> – the verb [行く]{いく} (to go) – because it ends in -く, you would expect it to become いいて, but it doesn't, it becomes [行って]{いって} (**<code>いって</code>**).
 
 ![](media/image1057.webp)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,16 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "cure-script",
       "dependencies": {
         "fs": "^0.0.1-security",
         "glob": "^10.3.10",
         "path": "^0.12.7"
       },
       "devDependencies": {
+        "@types/furigana-markdown-it": "^1.0.4",
         "@types/glob": "^8.1.0",
         "@types/node": "^20.11.25",
+        "furigana-markdown-it": "^1.0.3",
         "prettier": "^3.2.5",
         "typescript": "^5.4.2",
         "vitepress": "^1.5.0"
@@ -1126,6 +1127,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/furigana-markdown-it": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/furigana-markdown-it/-/furigana-markdown-it-1.0.4.tgz",
+      "integrity": "sha512-22lq1qnV0O1UTqANVRE8irGgqCGo0eeCYk7KxwFhIaTZtPTuRQzHGsfdGjJ4j5XyssHND0y6dU5L3CwX5moSYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "*"
+      }
+    },
     "node_modules/@types/glob": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
@@ -1867,6 +1878,13 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/furigana-markdown-it": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/furigana-markdown-it/-/furigana-markdown-it-1.0.3.tgz",
+      "integrity": "sha512-ydfcJ/gW3f88dRcX+tdftCM7pFSh2A5piHVa6MyfSO7Dtn3CKUQ/q5QtWj0dbuYVwtm+dS1mfHVPFXdP1UJDcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.3.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "devDependencies": {
+    "@types/furigana-markdown-it": "^1.0.4",
     "@types/glob": "^8.1.0",
     "@types/node": "^20.11.25",
+    "furigana-markdown-it": "^1.0.3",
     "prettier": "^3.2.5",
     "typescript": "^5.4.2",
     "vitepress": "^1.5.0"


### PR DESCRIPTION
I configured [furigana-markdown-it](https://github.com/iltrof/furigana-markdown-it) such that it is usable in vitepress. The syntax would be `[kanji]{furigana}`, e.g. `[今何時ですか]{いま なん じ ですか}？`. The plugin is also kind of smart and can match whole sentences, but then only applies the furigana to the kanji and skips the rest. Its documentation gives an overview on its possible usage.

I applied it to chapter one as an example. If it is acceptable, I can work on other chapters as well.

I'm not sure about the readability, though.