### PR TITLE
Fix backtick formatting

### DIFF
--- a/config/docs/14-adverbs-and-the-も-particle.md
+++ b/config/docs/14-adverbs-and-the-も-particle.md
@@ -166,7 +166,7 @@ Now, **も declares the topic of the sentence as well, but it always changes it.
 
 **When we change the topic with は, we are doing the opposite of that: we are drawing a distinction between the present topic and the previous topic.** So if we had said: 
 
-「アリス**は**お姉ちゃんのところに戻った」 – ところ` is `place` and 戻る is `return", so this would have meant Alice went back to her sister, to the place where her sister was, to her sister's place.
+「アリス**は**お姉ちゃんのところに戻った」 – ところ is `place` and 戻る is `return`, so this would have meant Alice went back to her sister, to the place where her sister was, to her sister's place.
 
 ![](media/image841.webp)
 


### PR DESCRIPTION
Fix a small backtick formatting issue.

[Before](https://kellenok.github.io/cure-script/14-adverbs-and-the-%E3%82%82-particle.html#:~:text=%E3%81%A8%E3%81%93%E3%82%8Displaceand%20%E6%88%BB%E3%82%8B%20isreturn%22)
![image](https://github.com/user-attachments/assets/35ea7c89-03f2-48f7-b528-a63c536e4a92)

After
![image](https://github.com/user-attachments/assets/f9ca08fd-f3df-4edc-9904-f7075bf8b465)
